### PR TITLE
PEP 387: Update changelog to mention 5-year deprecation period

### DIFF
--- a/peps/pep-0387.rst
+++ b/peps/pep-0387.rst
@@ -199,6 +199,7 @@ several releases:
 Changelog
 =========
 
+* 2025-Jan-27: Updated to prefer a 5-year deprecation period before removal.
 * 2023-Nov-14: Added ``@deprecated`` decorator per :pep:`702`.
 * 2023-Jul-03: Added the Soft Deprecation section, as discussed in
   `<https://discuss.python.org/t/27957>`__.


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brettcannon/peps/pull/2?shareId=88f11185-6cdd-4ab6-92f8-6ccbba0a4c83).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--2.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->